### PR TITLE
Use a git submodule to include A-Painter.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "a-painter"]
+	path = a-painter
+	url = https://github.com/aframevr/a-painter.git

--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 # A-Painter Socket Server Demo #
 A socket based multiplayer server example for a-painter
 
-We recently had the privilege to exhibit multipalyer A-Painter in the VR Showcase at SIGGRAPH Asia 2017. As a part of this we got in some local artists to try it out, you can see their paintings, and others, [here](https://mrfrase3.github.io/a-painterSA17/).
+We recently had the privilege to exhibit our [multiuser A-Painter](https://dl.acm.org/citation.cfm?id=3148451) project [in the VR Showcase at SIGGRAPH Asia 2017](https://sa2017.siggraph.org/attendees/vr-showcase?view=event&eid=145).  A selection of local artists (plus exhibition visitors) created VR artworks you can see [here](https://mrfrase3.github.io/a-painterSA17/).
 
 **Note:**
 This is a proof of concept only, **this should not be used in production**. There are serious vulnerabilities which would not fly in production.
 
 ----------
 ## Installation ##
-Pretty simple!  Install [Node.js](https://nodejs.org/en/download/) then...
+Pretty simple!  Install [Git](https://git-scm.com/downloads) and [Node.js](https://nodejs.org/en/download/) then...
 
- 1. Copy the URL for this code (`Clone or Download` button above)
- 1. Paste the URL at the end of this command: `git clone --recursive `
+ 1. Copy the URL for this repository (`Clone or Download` button above)
+ 1. Paste that URL at the end of this command &amp; hit Enter: `git clone --recursive `
  1. Run `npm install` in the resulting directory.
  1. Run `node server`
 
-Done!  A line like this in the output tells you which port to connect to:
+Done!  A line like this in the output tells you which port to point your browser at (for example http://localhost:3002):
 
     Server running on port 3002
 
-Remember to adjust your firewall settings for that port (TCP).
+Painters on other computers will need to use your server's IP address or hostname instead of "localhost" in the example URL above.  Remember to adjust your firewall settings for that port (TCP) so they have access (carefully!).
+
+You'll probably want to specify a "room" id in the URL, or each participant's browser will be randomly assigned a new, empty room (so lonely!).  We often use the date / time or a random fruit / vegetable (for example, "Let's all meet here: http://your.server:3002?room=tomato").
 
 ----------
 ## How it Works ##

--- a/README.md
+++ b/README.md
@@ -1,23 +1,29 @@
 # A-Painter Socket Server Demo #
 A socket based multiplayer server example for a-painter
 
-We recently had the privledge to exhibit multipalyer A-Painter in the VR Showcase at SIGGRAPH Asia 2017. As a part of this we got in some local artists to try it out, you can see their paintings, and others, [here](https://mrfrase3.github.io/a-painterSA17/).
+We recently had the privilege to exhibit multipalyer A-Painter in the VR Showcase at SIGGRAPH Asia 2017. As a part of this we got in some local artists to try it out, you can see their paintings, and others, [here](https://mrfrase3.github.io/a-painterSA17/).
 
 **Note:**
 This is a proof of concept only, **this should not be used in production**. There are serious vulnerabilities which would not fly in production.
 
 ----------
 ## Installation ##
-Pretty simple!
+Pretty simple!  Install [Node.js](https://nodejs.org/en/download/) then...
 
- 1. Download the repo to your test directory
- 2. Run `npm install`
- 3. Run `git clone https://github.com/aframevr/a-painter.git` 
- 4. Run `node server`
+ 1. Copy the URL for this code (`Clone or Download` button above)
+ 1. Paste the URL at the end of this command: `git clone --recursive `
+ 1. Run `npm install` in the resulting directory.
+ 1. Run `node server`
+
+Done!  A line like this in the output tells you which port to connect to:
+
+    Server running on port 3002
+
+Remember to adjust your firewall settings for that port (TCP).
 
 ----------
 ## How it Works ##
 
-This server uses a-painter's main repo, except instead of using a cli webpack server, it hosts its own express server with webpack implemented and then runs a socket.io server on top. It also injects the multiplayer layer into the client application.
+This server uses A-Painter's main repo, except instead of using a CLI Webpack server, it hosts its own Express server with Webpack implemented and then runs a Socket.io server on top. It also injects the multiplayer layer into the client application.
 
-This serves as a basic example and the method can easily be modified to support different communication types, like mongo, firebase, webRTC, etc... 
+This serves as a basic example and the method can easily be modified to support different communication types, like Mongo, Firebase, webRTC, etc... 


### PR DESCRIPTION
The server uses AFRAME.registerSystem() to extend the A-Painter code
that it serves up so that it shares headset, controller and stroke
data.  If the A-Painter or upstream A-Frame code changes, it isn't
always compatible with what the server does.  Using a submodule
simplifies deployment for users by using a version of the A-Painter
code known to be compatible with the server.

Updated the instructions in README.md to match the changes, provide
port/firewall tips and fix some typos.